### PR TITLE
Publish to npmjs from gitlab script

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,38 @@
+stages:
+  - install
+  - build
+  - lint
+  - test
+
+variables:
+  NODE_VERSION: "20"
+  CI_NODEJS_VERSION: $NODE_VERSION
+
+before_script:
+  - echo "Installing Node.js $CI_NODEJS_VERSION"
+  - curl -sL https://deb.nodesource.com/setup_$CI_NODEJS_VERSION.x | bash -
+  - apt-get install -y nodejs
+  - node -v
+  - npm -v
+  - npm ci
+
+install_dependencies:
+  stage: install
+  script:
+    - echo "Dependencies installed using npm ci"
+
+build:
+  stage: build
+  script:
+    - npm run build
+
+lint:
+  stage: lint
+  script:
+    - npm run lint
+
+unit_tests:
+  stage: test
+  script:
+    - npm run test:unit
+

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,6 +13,7 @@ stages:
   - build
   - lint
   - test
+  - release
 
 install_dependencies:
   stage: install
@@ -23,6 +24,9 @@ build:
   stage: build
   script:
     - npm run build
+  artifacts:
+    paths:
+      - dist/
 
 lint:
   stage: lint
@@ -34,16 +38,44 @@ unit_tests:
   script:
     - npm run test:unit
 
+release_dry_run:
+  stage: release
+  script:
+    - echo "//registry.npmjs.org/:_authToken=$TOKEN" > ~/.npmrc
+    - npm publish --dry-run
+    - rm -f ~/.npmrc
+  dependencies:
+    - build 
+    - lint
+    - unit_tests
+  when: manual 
+
+pre_release:
+  stage: release
+  script:
+    - echo "//registry.npmjs.org/:_authToken=$TOKEN" > ~/.npmrc
+    - npm publish --tag prerelease
+    - rm -f ~/.npmrc
+  rules:
+    # Only run the pre release step for Git tags (e.g., prerelease-v1.2.3, prerelease-v1.2.3-alpha etc)
+    - if: $CI_COMMIT_TAG =~ /^prerelease-v[0-9]+\.[0-9]+\.[0-9]+(?:-.+)?$/
+  dependencies:
+    - build 
+    - lint
+    - unit_tests
+  when: manual 
+
 release:
   stage: release
-  script: # update this to reuse above steps
-    - npm ci
-    - npm run build 
-    - npm run test:unit  
+  script:
     - echo "//registry.npmjs.org/:_authToken=$TOKEN" > ~/.npmrc
-    - npm publish # can add --dry-run flag for testing
+    - npm publish
     - rm -f ~/.npmrc
   rules:
     # Only run the release step for Git tags (e.g., v1.0.0)
     - if: $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*/
+  dependencies:
+    - build 
+    - lint
+    - unit_tests
   when: manual 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,3 +33,17 @@ unit_tests:
   stage: test
   script:
     - npm run test:unit
+
+release:
+  stage: release
+  script: # update this to reuse above steps
+    - npm ci
+    - npm run build 
+    - npm run test:unit  
+    - echo "//registry.npmjs.org/:_authToken=$TOKEN" > ~/.npmrc
+    - npm publish # can add --dry-run flag for testing
+    - rm -f ~/.npmrc
+  rules:
+    # Only run the release step for Git tags (e.g., v1.0.0)
+    - if: $CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+.*/
+  when: manual 


### PR DESCRIPTION
Work in progress.

Added release step:
 - builds and runs npm publish
 - only allows publishing on commits with a tag of vX.X.X
 -  must be manually triggered in gitlab

added pre-release steps for prerelease versions with a specific tag  (e.g., prerelease-v1.2.3, prerelease-v1.2.3-alpha etc)

added a dry run step to manually test the publish process

output dist file from build step to artifacts for release steps to use

To do:
 - confirm whether a more complicated script is needed to prepare release
