### PR TITLE
feat(sourcemaps): add include, exclude, dryRun options

### DIFF
--- a/src/commands/sourcemaps.ts
+++ b/src/commands/sourcemaps.ts
@@ -68,8 +68,16 @@ sourcemapsCommand
     'Path to the directory containing your production JavaScript bundles and their source maps'
   )
   .option(
+    '--include <patterns...>',
+    `A space-separated list of glob file patterns for selecting specific source map files to upload.`
+  )
+  .option(
+    '--exclude <patterns...>',
+    'A space-separated list of glob file patterns for selecting specific source map files to not upload.'
+  )
+  .option(
     '--dry-run',
-    'Use --dry-run to preview the files that will be injected for the given options, without modifying any files on the file system'
+    'Preview the files that will be injected for the given options'
   )
   .option(
     '--debug',
@@ -122,6 +130,18 @@ sourcemapsCommand
     'The application version used in your agent configuration'
   )
   .option(
+    '--include <patterns...>',
+    `A space-separated list of glob file patterns for selecting specific source map files to upload.`
+  )
+  .option(
+    '--exclude <patterns...>',
+    'A space-separated list of glob file patterns for selecting specific source map files to not upload.'
+  )
+  .option(
+    '--dry-run',
+    'Preview the files that will be uploaded for the given options'
+  )
+  .option(
     '--debug',
     'Enable debug logs'
   )
@@ -152,4 +172,6 @@ interface SourcemapsUploadCliOptions {
   appVersion?: string;
   dryRun?: boolean;
   debug?: boolean;
+  include?: string[];
+  exclude?: string[];
 }

--- a/src/sourcemaps/utils.ts
+++ b/src/sourcemaps/utils.ts
@@ -21,6 +21,8 @@ export const SOURCE_MAPPING_URL_COMMENT_PREFIX = '//# sourceMappingURL=';
 export const SNIPPET_PREFIX = `;/* olly sourcemaps inject */`;
 export const SNIPPET_TEMPLATE = `${SNIPPET_PREFIX}if (typeof window === 'object') { window.sourceMapIds = window.sourceMapIds || {}; let s = ''; try { throw new Error(); } catch (e) { s = (e.stack.match(/https?:\\/\\/[^\\s]+?(?::\\d+)?(?=:[\\d]+:[\\d]+)/) || [])[0]; } if (s) {window.sourceMapIds[s] = '__SOURCE_MAP_ID_PLACEHOLDER__';}};`;
 
+export const DEFAULT_JS_MAP_GLOB_PATTERN = '**/*.{js,cjs,mjs}.map';
+
 export function isJsFilePath(filePath: string) {
   return filePath.match(/\.(js|cjs|mjs)$/);
 }

--- a/src/utils/filesystem.ts
+++ b/src/utils/filesystem.ts
@@ -32,7 +32,7 @@ const TEMP_FILE_EXTENSION: string = '.olly.tmp';
  *  - path/to/dist/main.js.map
  *  - path/to/dist/nested/folder/page1.js
  */
-export async function readdirRecursive(dir: string) {
+export async function readdirRecursive(dir: string, include: string | string[] = '**/*', exclude: string[] = []) {
   // Using 'glob' instead of native 'readdir' due to:
   //   https://github.com/nodejs/node/issues/48858
   //   https://github.com/nodejs/node/issues/51773
@@ -41,9 +41,10 @@ export async function readdirRecursive(dir: string) {
   // that our user should know about, so try reading the dir before running glob
   await readdir(dir);
 
-  const partialPaths = await glob('**/*', {
+  const partialPaths = await glob(include, {
     cwd: dir,
     nodir: true,
+    ignore: exclude
   });
   return partialPaths.map(partialPath => path.join(dir, partialPath));
 }

--- a/test/utils/filesystem.test.ts
+++ b/test/utils/filesystem.test.ts
@@ -24,6 +24,17 @@ describe('filesystem.readdirRecursive', () => {
     expect(paths.every(p => p.startsWith('test'))).toBe(true);
   });
 
+  test('does not return files that should be excluded', async () => {
+    const allPaths = await readdirRecursive('test');
+    const paths = await readdirRecursive('test', undefined, ['**/filesystem.test.ts']);
+    expect(paths.length).toBeLessThan(allPaths.length);
+  });
+
+  test('only returns files that should be included', async () => {
+    const paths = await readdirRecursive('.', ['**/filesystem.test.ts']);
+    expect(paths.length).toEqual(1);
+  });
+
   test('should throw an error if "dir" is not a directory', async () => {
     await expect(readdirRecursive('package.json')).rejects.toThrowError(
       /ENOTDIR/


### PR DESCRIPTION
 - these are glob patterns that we pass directly to glob API, which was already being used to read directories

 - dryRun is newly-added for "upload" ("inject" already had dry-run)