### PR TITLE
feat(sourcemaps): warn user if upload is run before inject

### DIFF
--- a/src/sourcemaps/wasInjectAlreadyRun.ts
+++ b/src/sourcemaps/wasInjectAlreadyRun.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+import { Logger } from '../utils/logger';
+import { readFile } from 'fs/promises';
+import { existsSync } from 'fs';
+import path from 'node:path';
+
+interface WasInjectAlreadyRunResult {
+  result: boolean;
+  message: string;
+}
+
+/**
+ * Try to locate the JavaScript file and check that code injection already happened.
+ * This can let us warn users when they are uploading files that do not have source map IDs injected already.
+ */
+export async function wasInjectAlreadyRun(jsMapFilePath: string, logger: Logger): Promise<WasInjectAlreadyRunResult> {
+  const DEFAULT_WARN_MESSAGE = `Could not verify that the sourceMapId for ${jsMapFilePath} was injected into its related JavaScript file.`;
+
+  try {
+    const jsFilePath = await discoverJsFilePath(jsMapFilePath, logger);
+    if (!jsFilePath) {
+      return {
+        result: false,
+        message: DEFAULT_WARN_MESSAGE
+      };
+    }
+
+    const contents = await readFile(jsFilePath, { encoding: 'utf-8' });
+    if (isSnippetPresent(contents)) {
+      return {
+        result: true,
+        message: ''
+      };
+    } else {
+      return {
+        result: false,
+        message: `No sourceMapId was found in the related JavaScript file ${jsFilePath}. Make sure to run the "sourcemaps inject" command in addition to "sourcemaps upload".  Use --help to learn more.`
+      };
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  } catch (_e) {
+    return {
+      result: false,
+      message: DEFAULT_WARN_MESSAGE
+    };
+  }
+}
+
+async function discoverJsFilePath(jsMapFilePath: string, logger: Logger): Promise<string | null> {
+  // 1. Check for a file with the same name, but using ".js" extension
+  // Avoid reading the (potentially large) .js.map file if it's not needed
+  const pathWithoutMapExtension = jsMapFilePath.replace(/.map$/, '');
+  if (existsSync(pathWithoutMapExtension)) {
+    logger.debug('upload warning check: found source map pair (using standard naming convention)');
+    logger.debug(`  - ${pathWithoutMapExtension}`);
+    logger.debug(`  - ${jsMapFilePath}`);
+    return pathWithoutMapExtension;
+  }
+
+  // 2. Search for the "file" field in source map contents
+  const contents = await readFile(jsMapFilePath, { encoding: 'utf-8' });
+  const json = JSON.parse(contents) as { file?: unknown };
+  if (json.file && typeof json.file === 'string') {
+    logger.debug('upload warning check: found source map pair (using "file" property in the source map)');
+    logger.debug(`  - ${json.file}`);
+    logger.debug(`  - ${jsMapFilePath}`);
+    return path.join(
+      path.dirname(jsMapFilePath),
+      json.file
+    );
+  }
+
+
+  logger.debug(`pre-upload validation: no source map pair found for ${jsMapFilePath}`);
+  return null;
+}
+
+function isSnippetPresent(content: string): boolean {
+  /*
+   * Keep this check less-specific so we can avoid warning users who inject their code
+   * using other tools besides the CLI (i.e., build plugins).
+   *
+   * For example, you could inject using a build plugin, but use the CLI tool to upload files
+   * separately at a later point in the CI/CD process.
+   *
+   * The code snippet could look subtly different, so just check for existence of "window.sourceMapIds"
+   * to avoid false warning messages in the above scenario.
+   */
+  return content.includes('window.sourceMapIds');
+}

--- a/src/utils/spinner.ts
+++ b/src/utils/spinner.ts
@@ -47,9 +47,13 @@ export function createSpinner(): Spinner {
     updateText: (text) => oraSpinner.text = text,
     stop: () => oraSpinner.stop(),
     interrupt: (writeLogs) => {
-      oraSpinner.clear();
-      writeLogs();
-      oraSpinner.render();
+      if (oraSpinner.isSpinning) {
+        oraSpinner.clear();
+        writeLogs();
+        oraSpinner.render();
+      } else {
+        writeLogs();
+      }
     }
   };
 }

--- a/test/sourcemaps/wasInjectAlreadyRun.test.ts
+++ b/test/sourcemaps/wasInjectAlreadyRun.test.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+import { Logger } from '../../src/utils/logger';
+import { wasInjectAlreadyRun } from '../../src/sourcemaps/wasInjectAlreadyRun';
+import * as fs from 'fs';
+import * as fsPromises from 'fs/promises';
+import { SNIPPET_TEMPLATE } from '../../src/sourcemaps/utils';
+
+jest.mock('fs');
+jest.mock('fs/promises');
+
+describe('wasInjectAlreadyRun', () => {
+
+  const mockLogger: Logger = {
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn()
+  };
+
+  test('should return false for bundle.js.map when bundle.js exists but the snippet is not present', async () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);  // simulate that bundle.js exists
+    jest.spyOn(fsPromises, 'readFile').mockImplementation(async (path) => {
+      if (path === 'bundle.js.map') {
+        return getMockSourceMapContentWithoutFileProperty();
+      } else if (path === 'bundle.js') {
+        return getMockJsContentWithoutSnippet();
+      } else {
+        throw new Error('file not found');
+      }
+    });
+
+    const { result } = await wasInjectAlreadyRun('bundle.js.map', mockLogger);
+
+    expect(fs.existsSync).toBeCalledWith('bundle.js');
+    expect(result).toEqual(false);
+  });
+
+  test('should return true for bundle.js.map when bundle.js exists and the snippet is present', async () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);  // simulate that bundle.js exists
+    jest.spyOn(fsPromises, 'readFile').mockImplementation(async (path) => {
+      if (path === 'bundle.js.map') {
+        return getMockSourceMapContentWithoutFileProperty();
+      } else if (path === 'bundle.js') {
+        return getMockJsContentWithSnippet();
+      } else {
+        throw new Error('file not found');
+      }
+    });
+
+    const { result } = await wasInjectAlreadyRun('bundle.js.map', mockLogger);
+
+    expect(fs.existsSync).toBeCalledWith('bundle.js');
+    expect(result).toEqual(true);
+  });
+
+  test('should return false for bundle.js.map when no bundle.js exists', async () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false);  // simulate that bundle.js does not exist
+    jest.spyOn(fsPromises, 'readFile').mockImplementation(async (path) => {
+      if (path === 'bundle.js.map') {
+        return getMockSourceMapContentWithoutFileProperty();
+      } else {
+        throw new Error('file not found');
+      }
+    });
+
+    const { result } = await wasInjectAlreadyRun('bundle.js.map', mockLogger);
+
+    expect(fs.existsSync).toBeCalledWith('bundle.js');
+    expect(result).toEqual(false);
+  });
+
+  test('should return true for bundle.js.map when ../bundles/bundle.js exists and has the snippet', async () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false);  // simulate that bundle.js does not exist
+    jest.spyOn(fsPromises, 'readFile').mockImplementation(async (path) => {
+      if (path === 'bundle.js.map') {
+        return getMockSourceMapContentWithFileProperty();
+      } else if (path === '../bundles/bundle.js') {
+        return getMockJsContentWithSnippet();
+      } else {
+        throw new Error('file not found');
+      }
+    });
+
+    const { result } = await wasInjectAlreadyRun('bundle.js.map', mockLogger);
+
+    expect(result).toEqual(true);
+  });
+
+  test('should return false when ../bundles/bundle.js (and bundle.js) do not exist', async () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false);  // simulate that bundle.js does not exist
+    jest.spyOn(fsPromises, 'readFile').mockImplementation(async (path) => {
+      if (path === 'bundle.js.map') {
+        return getMockSourceMapContentWithFileProperty();
+      } else {
+        throw new Error('file not found');
+      }
+    });
+
+    const { result } = await wasInjectAlreadyRun('bundle.js.map', mockLogger);
+
+    expect(result).toEqual(false);
+  });
+});
+
+/** Use this mock source map when the test should be concerned with the JS file path "../bundles/bundle.js" */
+function getMockSourceMapContentWithFileProperty(): string {
+  return JSON.stringify({ version: 3, file: '../bundles/bundle.js' });
+}
+
+function getMockSourceMapContentWithoutFileProperty(): string {
+  return JSON.stringify({ version: 3 });
+}
+
+function getMockJsContentWithSnippet(): string {
+  return `console.log("Hello world")\n${SNIPPET_TEMPLATE}`;
+}
+
+function getMockJsContentWithoutSnippet(): string {
+  return `console.log("Hello world")\n`;
+}


### PR DESCRIPTION
General strategy (as mentioned in code comments):
 1a) Given a source map path, try looking for JS file with the same name (but without .map suffix)
 1b) Else, parse the source map file, and treat the "file" property as a relative file path
 2) Check that file's contents for presence of "window.sourceMapIds"
 3) If nothing is found, emit a WARN log to help inform the user that they may have missed a step