### PR TITLE
Integrate android upload commands with backend

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,38 @@
+stages:
+  - install
+  - build
+  - lint
+  - test
+
+variables:
+  NODE_VERSION: "20"
+  CI_NODEJS_VERSION: $NODE_VERSION
+
+before_script:
+  - echo "Installing Node.js $CI_NODEJS_VERSION"
+  - curl -sL https://deb.nodesource.com/setup_$CI_NODEJS_VERSION.x | bash -
+  - apt-get install -y nodejs
+  - node -v
+  - npm -v
+  - npm ci
+
+install_dependencies:
+  stage: install
+  script:
+    - echo "Dependencies installed using npm ci"
+
+build:
+  stage: build
+  script:
+    - npm run build
+
+lint:
+  stage: lint
+  script:
+    - npm run lint
+
+unit_tests:
+  stage: test
+  script:
+    - npm run test:unit
+


### PR DESCRIPTION
Added an uploadFileAndroid method that both android upload commands call:
  - checks whether its plain txt or gzip and adds that to content type.
  - adds content length, type, and token to request header
  - adds params to request

In android command class:
- Added dynamic endpoint generation in android command class, based on the O11Y_REALM, SPLUNK_O11Y_TOKEN env variables (or default values), and command params
- Throws error if token not set in env variables.
- Adds command parameters, token, mapping file, and url to request before making it

Tested in lab0 environment