### PR TITLE
Feature/demrum 1581 move upload code to library function

### DIFF
--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -160,9 +160,11 @@ iOSCommand
           if (error instanceof UserFriendlyError) {
             logger.error(error.message);
             logger.debug(`Original error: ${error.originalError instanceof Error ? error.originalError.stack : 'No stack trace available'}`);
+	    cleanupTemporaryZips(uploadPath);
             iOSCommand.error(error.message);
           } else {
             logger.error('Unknown error during upload');
+	    cleanupTemporaryZips(uploadPath);
             iOSCommand.error('Unknown error during upload');
           }
         }

--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -72,7 +72,7 @@ const generateUrl = ({
 };
 
 iOSCommand
-  .description(helpDescription)
+  .description(helpDescription);
 
 iOSCommand
   .command('upload')

--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -232,9 +232,6 @@ iOSCommand
         logger.error(error.message);
         logger.debug(`Original error: ${error.originalError instanceof Error ? error.originalError.stack : 'No stack trace available'}`);
         iOSCommand.error(error.message);
-      } else if (error instanceof Error) {
-        logger.error(`Failed to fetch the list of uploaded files: ${error.message}`);
-        iOSCommand.error(`Error during list operation: ${error.message}`);
       } else {
         logger.error('Failed to fetch the list of uploaded files: An unknown error occurred.');
         iOSCommand.error('Error occurred during the list operation.');

--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -168,7 +168,7 @@ iOSCommand
 
       // Report failed uploads if there are any
       if (failedUploads.length > 0) {
-        iOSCommand.error(`The following files failed to upload: ${failedUploads.join(', ')}`);
+        iOSCommand.error(`Upload failed for ${failedUploads.length} file${failedUploads.length !== 1 ? 's' : ''}`);
       } else {
         logger.info('All files uploaded successfully.');
       }

--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -159,7 +159,6 @@ iOSCommand
           failedUploads++;
           if (error instanceof UserFriendlyError) {
             logger.error(error.message);
-            logger.debug(`Original error: ${error.originalError instanceof Error ? error.originalError.stack : 'No stack trace available'}`);
             cleanupTemporaryZips(uploadPath);
             iOSCommand.error(error.message);
           } else {
@@ -182,7 +181,6 @@ iOSCommand
     } catch (error) {
       if (error instanceof UserFriendlyError) {
         logger.error(error.message);
-        logger.debug(`Original error: ${error.originalError instanceof Error ? error.originalError.stack : 'No stack trace available'}`);
         iOSCommand.error(error.message);
       } else {
         logger.error('An unexpected error occurred:', error);
@@ -232,7 +230,6 @@ iOSCommand
     } catch (error) {
       if (error instanceof UserFriendlyError) {
         logger.error(error.message);
-        logger.debug(`Original error: ${error.originalError instanceof Error ? error.originalError.stack : 'No stack trace available'}`);
         iOSCommand.error(error.message);
       } else {
         logger.error('Failed to fetch the list of uploaded files: An unknown error occurred.');

--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -229,7 +229,7 @@ iOSCommand
       });
     } catch (error) {
       if (error instanceof UserFriendlyError) {
-        logger.error(`User-friendly error: ${error.message}`);
+        logger.error(error.message);
         logger.debug(`Original error: ${error.originalError instanceof Error ? error.originalError.stack : 'No stack trace available'}`);
         iOSCommand.error(error.message);
       } else if (error instanceof Error) {

--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -161,9 +161,6 @@ iOSCommand
             logger.error(error.message);
             logger.debug(`Original error: ${error.originalError instanceof Error ? error.originalError.stack : 'No stack trace available'}`);
             iOSCommand.error(error.message);
-          } else if (error instanceof Error) {
-            logger.error(`Failed to upload ${basename(filePath)}: ${error.message}`);
-            iOSCommand.error(`Error during upload: ${error.message}`);
           } else {
             logger.error('Unknown error during upload');
             iOSCommand.error('Unknown error during upload');

--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -160,11 +160,11 @@ iOSCommand
           if (error instanceof UserFriendlyError) {
             logger.error(error.message);
             logger.debug(`Original error: ${error.originalError instanceof Error ? error.originalError.stack : 'No stack trace available'}`);
-	    cleanupTemporaryZips(uploadPath);
+            cleanupTemporaryZips(uploadPath);
             iOSCommand.error(error.message);
           } else {
             logger.error('Unknown error during upload');
-	    cleanupTemporaryZips(uploadPath);
+            cleanupTemporaryZips(uploadPath);
             iOSCommand.error('Unknown error during upload');
           }
         }

--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -52,7 +52,7 @@ const listdSYMsDescription = `This subcommand retrieves and shows a list of the 
 By default, it returns the last 100 dSYMs uploaded, sorted in reverse chronological order based on the upload timestamp.
 `;
 
-const helpDescription = `Upload and list zipped iOS symbolication files (dSYMs)
+const helpDescription = `Upload and list iOS symbolication files (dSYMs)
 
 For each respective command listed below under 'Commands', please run 'o11y-dem-cli ios <command> --help' for an overview of its usage and options
 `;
@@ -73,12 +73,6 @@ const generateUrl = ({
 
 iOSCommand
   .description(helpDescription)
-  .addHelpText('after', `
-Examples:
-  $ o11y-dem-cli ios upload --path /path/to/dSYMs --realm us0
-  $ o11y-dem-cli ios list --realm us0
-  `);
-
 
 iOSCommand
   .command('upload')

--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -156,7 +156,7 @@ iOSCommand
             TOKEN_HEADER,
           });
         } catch (error) {
-	  failedUploads++;
+          failedUploads++;
           if (error instanceof UserFriendlyError) {
             logger.error(error.message);
             logger.debug(`Original error: ${error.originalError instanceof Error ? error.originalError.stack : 'No stack trace available'}`);

--- a/src/dsyms/dsymClient.ts
+++ b/src/dsyms/dsymClient.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+import axios from 'axios';
+import fs from 'fs';
+import { AxiosError } from 'axios';
+import { Logger } from '../utils/logger';  // Adjust the import path as necessary
+import { Spinner } from '../utils/spinner'; // Adjust the import path as necessary
+
+interface UploadParams {
+  filePath: string;
+  url: string;
+  token: string;
+  logger: Logger;
+  spinner: Spinner;
+  TOKEN_HEADER: string;
+}
+
+export async function uploadDSYM({ filePath, url, token, logger, spinner, TOKEN_HEADER }: UploadParams): Promise<void> {
+  const fileSizeInBytes = fs.statSync(filePath).size;
+  const fileStream = fs.createReadStream(filePath);
+  const headers = {
+    'Content-Type': 'application/zip',
+    [TOKEN_HEADER]: token,
+    'Content-Length': fileSizeInBytes,
+  };
+
+  spinner.start(`Uploading file: ${filePath}`);
+
+  try {
+    await axios.put(url, fileStream, { headers });
+    spinner.stop();
+    logger.info(`Upload complete for ${filePath}`);
+  } catch (error) {
+    spinner.stop();
+    const ae = error as AxiosError;
+    const unableToUploadMessage = `Unable to upload ${filePath}`;
+
+    if (ae.response && ae.response.status === 413) {
+      logger.warn(`${ae.response.status} ${ae.response.statusText}`);
+      logger.warn(unableToUploadMessage);
+    } else if (ae.response) {
+      logger.error(`${ae.response.status} ${ae.response.statusText}`);
+      logger.error(ae.response.data);
+      logger.error(unableToUploadMessage);
+    } else if (ae.request) {
+      logger.error(`Response from ${url} was not received`);
+      logger.error(ae.cause);
+      logger.error(unableToUploadMessage);
+    } else {
+      logger.error(`Request to ${url} could not be sent`);
+      logger.error(error);
+      logger.error(unableToUploadMessage);
+    }
+    throw new Error(unableToUploadMessage);
+  }
+}
+
+interface ListParams {
+  url: string;
+  token: string;
+  logger: Logger;
+  TOKEN_HEADER: string;
+}
+
+export async function listDSYMs({ url, token, logger, TOKEN_HEADER }: ListParams): Promise<void> {
+  try {
+    const response = await axios.get(url, {
+      headers: {
+        'Content-Type': 'application/json',
+        [TOKEN_HEADER]: token,
+      },
+    });
+    logger.info('Raw Response Data:', JSON.stringify(response.data, null, 2));
+  } catch (error) {
+    if (error instanceof AxiosError && error.response) {
+      logger.error(`HTTP ${error.response.status}: ${error.response.statusText}`);
+      logger.error(error.response.data);
+    } else if (error instanceof Error) {
+      logger.error('Failed to fetch the list of uploaded files:', error.message);
+    } else {
+      logger.error('Failed to fetch the list of uploaded files:', String(error));
+    }
+    throw error;  // Re-throw to handle it in the action handler
+  }
+}

--- a/src/dsyms/dsymClient.ts
+++ b/src/dsyms/dsymClient.ts
@@ -17,7 +17,6 @@
 import axios from 'axios';
 import { handleAxiosError } from '../utils/httpUtils';
 import fs from 'fs';
-import { AxiosError } from 'axios';
 import { Logger } from '../utils/logger';
 import { Spinner } from '../utils/spinner';
 

--- a/src/dsyms/dsymClient.ts
+++ b/src/dsyms/dsymClient.ts
@@ -17,8 +17,8 @@
 import axios from 'axios';
 import fs from 'fs';
 import { AxiosError } from 'axios';
-import { Logger } from '../utils/logger';  // Adjust the import path as necessary
-import { Spinner } from '../utils/spinner'; // Adjust the import path as necessary
+import { Logger } from '../utils/logger';
+import { Spinner } from '../utils/spinner';
 
 interface UploadParams {
   filePath: string;
@@ -94,6 +94,6 @@ export async function listDSYMs({ url, token, logger, TOKEN_HEADER }: ListParams
     } else {
       logger.error('Failed to fetch the list of uploaded files:', String(error));
     }
-    throw error;  // Re-throw to handle it in the action handler
+    throw error;
   }
 }

--- a/src/dsyms/dsymClient.ts
+++ b/src/dsyms/dsymClient.ts
@@ -50,7 +50,7 @@ export async function uploadDSYM({ filePath, url, token, logger, spinner, TOKEN_
     const operationMessage = `Unable to upload ${filePath}`;
     const result = handleAxiosError(error, operationMessage, url, logger);
     if (result) {
-      const userFriendlyMessage = `Failed to upload ${filePath}. Please check your network connection and ensure the file size does not exceed the limit.`;
+      const userFriendlyMessage = `Failed to upload ${filePath}. Please check your network connection or your realm and token values, and ensure the file size does not exceed the limit.`;
       throw new UserFriendlyError(error, userFriendlyMessage);
     }
   }

--- a/src/dsyms/dsymClient.ts
+++ b/src/dsyms/dsymClient.ts
@@ -19,6 +19,7 @@ import { handleAxiosError } from '../utils/httpUtils';
 import fs from 'fs';
 import { Logger } from '../utils/logger';
 import { Spinner } from '../utils/spinner';
+import { UserFriendlyError } from '../utils/userFriendlyErrors';
 
 interface UploadParams {
   filePath: string;
@@ -47,8 +48,10 @@ export async function uploadDSYM({ filePath, url, token, logger, spinner, TOKEN_
   } catch (error) {
     spinner.stop();
     const operationMessage = `Unable to upload ${filePath}`;
-    if (!handleAxiosError(error, operationMessage, url, logger)) {
-      throw new Error(operationMessage);
+    const result = handleAxiosError(error, operationMessage, url, logger);
+    if (result) {
+      const userFriendlyMessage = `Failed to upload ${filePath}. Please check your network connection and ensure the file size does not exceed the limit.`;
+      throw new UserFriendlyError(error, userFriendlyMessage);
     }
   }
 }
@@ -71,8 +74,11 @@ export async function listDSYMs({ url, token, logger, TOKEN_HEADER }: ListParams
     logger.info('Raw Response Data:', JSON.stringify(response.data, null, 2));
   } catch (error) {
     const operationMessage = 'Unable to fetch the list of uploaded files.';
-    if (!handleAxiosError(error, operationMessage, url, logger)) {
-      throw new Error(operationMessage);
+    const result = handleAxiosError(error, operationMessage, url, logger);
+    if (result) {
+      const userFriendlyMessage = `There was a problem accessing the list of uploaded files. 
+      Please check your network connection or try again later.`;
+      throw new UserFriendlyError(error, userFriendlyMessage);
     }
   }
 }

--- a/src/sourcemaps/index.ts
+++ b/src/sourcemaps/index.ts
@@ -27,7 +27,6 @@ import { injectFile } from './injectFile';
 import { Logger } from '../utils/logger';
 import { Spinner } from '../utils/spinner';
 import { handleAxiosError, uploadFile } from '../utils/httpUtils';
-import { AxiosError } from 'axios';
 import { formatUploadProgress } from '../utils/stringUtils';
 import { wasInjectAlreadyRun } from './wasInjectAlreadyRun';
 

--- a/src/sourcemaps/index.ts
+++ b/src/sourcemaps/index.ts
@@ -29,6 +29,7 @@ import { Spinner } from '../utils/spinner';
 import { handleAxiosError, uploadFile } from '../utils/httpUtils';
 import { formatUploadProgress } from '../utils/stringUtils';
 import { wasInjectAlreadyRun } from './wasInjectAlreadyRun';
+import { UserFriendlyError } from '../utils/userFriendlyErrors';
 
 export type SourceMapInjectOptions = {
   directory: string;
@@ -218,9 +219,15 @@ export async function runSourcemapUpload(options: SourceMapUploadOptions, ctx: S
     } catch (e) {
       failed++;
       spinner.stop();
-
+    
       const operationMessage = `Unable to upload ${path}`;
-      if (!handleAxiosError(e, operationMessage, url, logger)) {
+      const result = handleAxiosError(e, operationMessage, url, logger);
+      if (result) {
+        // Log or handle based on error category
+        const userFriendlyMessage = `Failed to upload ${path}. Please check the error log for more details.`;
+        logger.error(`Error category: ${result.category}`);
+        throw new UserFriendlyError(e, userFriendlyMessage);
+      } else {
         logger.error(operationMessage);
       }
     }

--- a/src/sourcemaps/index.ts
+++ b/src/sourcemaps/index.ts
@@ -26,7 +26,7 @@ import { computeSourceMapId } from './computeSourceMapId';
 import { injectFile } from './injectFile';
 import { Logger } from '../utils/logger';
 import { Spinner } from '../utils/spinner';
-import { uploadFile } from '../utils/httpUtils';
+import { handleAxiosError, uploadFile } from '../utils/httpUtils';
 import { AxiosError } from 'axios';
 import { formatUploadProgress } from '../utils/stringUtils';
 import { wasInjectAlreadyRun } from './wasInjectAlreadyRun';

--- a/src/sourcemaps/index.ts
+++ b/src/sourcemaps/index.ts
@@ -220,24 +220,9 @@ export async function runSourcemapUpload(options: SourceMapUploadOptions, ctx: S
       failed++;
       spinner.stop();
 
-      const ae = e as AxiosError;
-      const unableToUploadMessage = `Unable to upload ${path}`;
-
-      if (ae.response && ae.response.status === 413) {
-        logger.warn(ae.response.status, ae.response.statusText);
-        logger.warn(unableToUploadMessage);
-      } else if (ae.response) {
-        logger.error(ae.response.status, ae.response.statusText);
-        logger.error(ae.response.data);
-        logger.error(unableToUploadMessage);
-      } else if (ae.request) {
-        logger.error(`Response from ${url} was not received`);
-        logger.error(ae.cause);
-        logger.error(unableToUploadMessage);
-      } else {
-        logger.error(`Request to ${url} could not be sent`);
-        logger.error(e);
-        logger.error(unableToUploadMessage);
+      const operationMessage = `Unable to upload ${path}`;
+      if (!handleAxiosError(e, operationMessage, url, logger)) {
+        logger.error(operationMessage);
       }
     }
   }

--- a/src/utils/httpUtils.ts
+++ b/src/utils/httpUtils.ts
@@ -15,7 +15,6 @@
 */
 
 import axios from 'axios';
-import { AxiosError } from 'axios';
 import fs from 'fs';
 import FormData from 'form-data';
 import { Logger } from '../utils/logger';

--- a/src/utils/httpUtils.ts
+++ b/src/utils/httpUtils.ts
@@ -15,6 +15,7 @@
 */
 
 import axios from 'axios';
+import { AxiosError } from 'axios';
 import fs from 'fs';
 import FormData from 'form-data';
 


### PR DESCRIPTION
DEMRUM-1581

- Moving the upload code into a library function in a dedicated directory for iOS, ../dsyms/
- Updating upload for loop to continue on failure, gathering list of any failures and reporting them at the end.
- Also moved the network calls for the list command into a library function in the same location.
- Small UX tweaks: removed Examples section while we work out how to structure help.
