### PR TITLE
fix: do not log O11Y_TOKEN in --help for sourcemaps command

### DIFF
--- a/src/commands/android.ts
+++ b/src/commands/android.ts
@@ -16,12 +16,13 @@
 
 import { Command } from 'commander';
 import { extractManifestData } from '../utils/androidManifestUtils';
-import { 
-  isValidFile, 
+import {
+  isValidFile,
   hasValidExtension,
-  isValidAppId, 
-  isValidVersionCode, 
-  isValidUniqueId 
+  isValidAppId,
+  isValidVersionCode,
+  isValidUniqueId,
+  COMMON_ERROR_MESSAGES
 } from '../utils/inputValidations';
 import { UserFriendlyError } from '../utils/userFriendlyErrors';
 import { createLogger, LogLevel } from '../utils/logger';
@@ -230,13 +231,13 @@ androidCommand
   .action(async (options: UploadAndroidWithManifestOptions) => {
     const token = options.token || process.env.O11Y_TOKEN;
     if (!token) {
-      androidCommand.error('Error: API access token is required. Please pass it into the command as the --token option, or set using the environment variable O11Y_TOKEN');
+      androidCommand.error(COMMON_ERROR_MESSAGES.TOKEN_NOT_SPECIFIED);
     } else {
       options.token = token;
     }
 
     if (!options.realm || options.realm.trim() === '') {
-      androidCommand.error('Error: Realm is required and cannot be empty. Please pass it into the command as the --realm option, or set using the environment variable O11Y_REALM');
+      androidCommand.error(COMMON_ERROR_MESSAGES.REALM_NOT_SPECIFIED);
     }
 
     const logger = createLogger(options.debug ? LogLevel.DEBUG : LogLevel.INFO);

--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -23,6 +23,7 @@ import { createSpinner } from '../utils/spinner';
 import { createLogger, LogLevel } from '../utils/logger';
 import { validateDSYMsPath, cleanupTemporaryZips, getZippedDSYMs } from '../dsyms/iOSdSYMUtils';
 import { UserFriendlyError } from '../utils/userFriendlyErrors';
+import { COMMON_ERROR_MESSAGES } from '../utils/inputValidations';
 
 interface UploadCommandOptions {
   path: string;
@@ -103,7 +104,7 @@ iOSCommand
   .action(async (options: UploadCommandOptions) => {
     const token = options.token || process.env.O11Y_TOKEN;
     if (!token) {
-      iOSCommand.error('Error: API access token is required.');
+      iOSCommand.error(COMMON_ERROR_MESSAGES.TOKEN_NOT_SPECIFIED);
     }
     options.token = token;
 

--- a/src/commands/sourcemaps.ts
+++ b/src/commands/sourcemaps.ts
@@ -19,6 +19,7 @@ import { runSourcemapInject, runSourcemapUpload, SourceMapInjectOptions } from '
 import { UserFriendlyError } from '../utils/userFriendlyErrors';
 import { createLogger, LogLevel } from '../utils/logger';
 import { createSpinner } from '../utils/spinner';
+import { COMMON_ERROR_MESSAGES } from '../utils/inputValidations';
 
 export const sourcemapsCommand = new Command('sourcemaps');
 
@@ -124,10 +125,9 @@ sourcemapsCommand
     'Realm for your organization (example: us0).  Can also be set using the environment variable O11Y_REALM',
     process.env.O11Y_REALM
   )
-  .requiredOption(
+  .option(
     '--token <value>',
     'API access token.  Can also be set using the environment variable O11Y_TOKEN',
-    process.env.O11Y_TOKEN
   )
   .option(
     '--app-name <value>',
@@ -155,6 +155,16 @@ sourcemapsCommand
   )
   .action(
     async (options: SourcemapsUploadCliOptions) => {
+      const token = options.token || process.env.O11Y_TOKEN;
+      if (!token) {
+        sourcemapsCommand.error(COMMON_ERROR_MESSAGES.TOKEN_NOT_SPECIFIED);
+      } else {
+        options.token = token;
+      }
+      if (!options.realm || options.realm.trim() === '') {
+        sourcemapsCommand.error(COMMON_ERROR_MESSAGES.REALM_NOT_SPECIFIED);
+      }
+
       const logger = createLogger(options.debug ? LogLevel.DEBUG : LogLevel.INFO);
       const spinner = createSpinner();
       try {

--- a/src/utils/inputValidations.ts
+++ b/src/utils/inputValidations.ts
@@ -17,6 +17,11 @@
 import fs from 'fs';
 import path from 'path';
 
+export const COMMON_ERROR_MESSAGES = {
+  TOKEN_NOT_SPECIFIED: 'Error: API access token is required. Please pass it into the command as the --token option, or set using the environment variable O11Y_TOKEN',
+  REALM_NOT_SPECIFIED: 'Error: Realm is required and cannot be empty. Please pass it into the command as the --realm option, or set using the environment variable O11Y_REALM'
+};
+
 // Check if a file exists
 export const isValidFile = (filePath: string): boolean => {
   return fs.existsSync(filePath);


### PR DESCRIPTION
Followed the android example, and extracted error message to a common string