### PR TITLE
Rename CLI tool to "splunk-rum" and use consistent terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can now run `splunk-rum` locally from the command line:
 splunk-rum --version
 ```
 
-To develop locally, you can use the `build:watch` script to automatically re-build your changes:
+To develop locally, you can use the `build:watch` script to automatically rebuild the project as you make changes:
 ```
 npm run build:watch
 ```

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 
 * This tool is still under development, so the readme and source code are not yet complete
 
-# O11Y DEM CLI
+# Splunk RUM CLI
 
-The DEM CLI Tool helps developers upload Android mapping files, iOS dSYM files, and browser source map files to the Splunk O11y Cloud backend for deobfuscating stack traces. This tool is part of Splunk's Digital Experience Monitoring (DEM) suite.
+The Splunk RUM CLI helps developers upload Android mapping files, iOS dSYM files, and browser source map files to the Splunk Observability Cloud backend for deobfuscating stack traces. This tool is part of Splunk's Real User Monitoring (RUM) suite.
 
 ## Features
 
@@ -16,15 +16,33 @@ The DEM CLI Tool helps developers upload Android mapping files, iOS dSYM files, 
 
 ## Documentation
 
-For official documentation on the Splunk O11Y DEM CLI Tool, see _______
+For official documentation on the Splunk RUM CLI, see _______
 
 ## Getting Started
 
 ## Build and Development
 
+To build locally, run the following commands:
+
+```
+npm install
+npm build
+npm link
+```
+
+You can now run `splunk-rum` locally from the command line:
+```
+splunk-rum --version
+```
+
+To develop locally, you can use the `build:watch` script to automatically re-build your changes:
+```
+npm run build:watch
+```
+
 ## Troubleshooting
 
 # License
 
-The Splunk O11Y DEM CLI Tool is licensed under the terms of the Apache Software License
+The Splunk RUM CLI is licensed under the terms of the Apache Software License
 version 2.0. See [the license file](./LICENSE) for more details.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "o11y-dem-cli",
+  "name": "@splunk/rum-cli",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "o11y-dem-cli",
+      "name": "@splunk/rum-cli",
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -18,7 +18,7 @@
         "xml2js": "^0.6.2"
       },
       "bin": {
-        "o11y-dem-cli": "dist/index.js"
+        "splunk-rum": "dist/index.js"
       },
       "devDependencies": {
         "@stylistic/eslint-plugin": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "o11y-dem-cli",
+  "name": "@splunk/rum-cli",
   "version": "0.0.0",
   "description": "Tools for handling symbol and mapping files for symbolication",
   "main": "./dist/index.js",
@@ -42,6 +42,6 @@
     "typescript": "^5.6.3"
   },
   "bin": {
-    "o11y-dem-cli": "dist/index.js"
+    "splunk-rum": "dist/index.js"
   }
 }

--- a/src/commands/android.ts
+++ b/src/commands/android.ts
@@ -94,7 +94,7 @@ interface UploadAndroidWithManifestOptions {
 
 const shortDescription = 'Upload and list zipped or unzipped Proguard/R8 mapping.txt files';
 
-const detailedHelp = `For each respective command listed below under 'Commands', please run 'o11y-dem-cli android <command> --help' for an overview of its usage and options`;
+const detailedHelp = `For each respective command listed below under 'Commands', please run 'splunk-rum android <command> --help' for an overview of its usage and options`;
 
 androidCommand
   .description(shortDescription)

--- a/src/commands/android.ts
+++ b/src/commands/android.ts
@@ -116,8 +116,8 @@ androidCommand
   .requiredOption('--version-code <int>', 'Version code')
   .requiredOption('--path <path>', 'Path to the mapping file')
   .requiredOption('--realm <value>',
-    'Realm for your organization (example: us0).  Can also be set using the environment variable O11Y_REALM',
-    process.env.O11Y_REALM
+    'Realm for your organization (example: us0).  Can also be set using the environment variable SPLUNK_REALM',
+    process.env.SPLUNK_REALM
   )
   .option(
     '--token <value>',
@@ -135,7 +135,7 @@ androidCommand
     }
 
     if (!options.realm || options.realm.trim() === '') {
-      androidCommand.error('Error: Realm is required and cannot be empty. Please pass it into the command as the --realm option, or set using the environment variable O11Y_REALM');
+      androidCommand.error('Error: Realm is required and cannot be empty. Please pass it into the command as the --realm option, or set using the environment variable SPLUNK_REALM');
     }
 
     const logger = createLogger(options.debug ? LogLevel.DEBUG : LogLevel.INFO);
@@ -224,8 +224,8 @@ androidCommand
   .requiredOption('--manifest <path>', 'Path to the packaged AndroidManifest.xml file')
   .requiredOption('--path <path>', 'Path to the mapping.txt file')
   .requiredOption('--realm <value>',
-    'Realm for your organization (example: us0).  Can also be set using the environment variable O11Y_REALM',
-    process.env.O11Y_REALM
+    'Realm for your organization (example: us0).  Can also be set using the environment variable SPLUNK_REALM',
+    process.env.SPLUNK_REALM
   )
   .option(
     '--token <value>',
@@ -353,8 +353,8 @@ androidCommand
   .summary(`Retrieves list of metadata of all uploaded Proguard/R8 mapping files`)
   .requiredOption('--app-id <value>', 'Application ID')
   .requiredOption('--realm <value>',
-    'Realm for your organization (example: us0).  Can also be set using the environment variable O11Y_REALM',
-    process.env.O11Y_REALM
+    'Realm for your organization (example: us0).  Can also be set using the environment variable SPLUNK_REALM',
+    process.env.SPLUNK_REALM
   )
   .option(
     '--token <value>',
@@ -371,7 +371,7 @@ androidCommand
     }
 
     if (!options.realm || options.realm.trim() === '') {
-      androidCommand.error('Error: Realm is required and cannot be empty. Please pass it into the command as the --realm option, or set using the environment variable O11Y_REALM');
+      androidCommand.error('Error: Realm is required and cannot be empty. Please pass it into the command as the --realm option, or set using the environment variable SPLUNK_REALM');
     }
 
     const logger = createLogger(options.debug ? LogLevel.DEBUG : LogLevel.INFO);

--- a/src/commands/android.ts
+++ b/src/commands/android.ts
@@ -121,21 +121,21 @@ androidCommand
   )
   .option(
     '--token <value>',
-    'API access token. Can also be set using the environment variable O11Y_TOKEN'
+    'API access token. Can also be set using the environment variable SPLUNK_ACCESS_TOKEN'
   )
   .option('--splunk-build-id <value>', 'Optional Splunk Build ID for the upload')
   .option( '--dry-run', 'Preview the file that will be uploaded')
   .option('--debug', 'Enable debug logs')
   .action(async (options: UploadAndroidOptions) => {
-    const token = options.token || process.env.O11Y_TOKEN;
+    const token = options.token || process.env.SPLUNK_ACCESS_TOKEN;
     if (!token) {
-      androidCommand.error('Error: API access token is required. Please pass it into the command as the --token option, or set using the environment variable O11Y_TOKEN');
+      androidCommand.error(COMMON_ERROR_MESSAGES.TOKEN_NOT_SPECIFIED);
     } else {
       options.token = token;
     }
 
     if (!options.realm || options.realm.trim() === '') {
-      androidCommand.error('Error: Realm is required and cannot be empty. Please pass it into the command as the --realm option, or set using the environment variable SPLUNK_REALM');
+      androidCommand.error(COMMON_ERROR_MESSAGES.REALM_NOT_SPECIFIED);
     }
 
     const logger = createLogger(options.debug ? LogLevel.DEBUG : LogLevel.INFO);
@@ -229,12 +229,12 @@ androidCommand
   )
   .option(
     '--token <value>',
-    'API access token. Can also be set using the environment variable O11Y_TOKEN'
+    'API access token. Can also be set using the environment variable SPLUNK_ACCESS_TOKEN'
   )
   .option('--dry-run', 'Preview the file that will be uploaded and the parameters extracted from the AndroidManifest.xml file')
   .option('--debug', 'Enable debug logs')
   .action(async (options: UploadAndroidWithManifestOptions) => {
-    const token = options.token || process.env.O11Y_TOKEN;
+    const token = options.token || process.env.SPLUNK_ACCESS_TOKEN;
     if (!token) {
       androidCommand.error(COMMON_ERROR_MESSAGES.TOKEN_NOT_SPECIFIED);
     } else {
@@ -358,16 +358,16 @@ androidCommand
   )
   .option(
     '--token <value>',
-    'API access token. Can also be set using the environment variable O11Y_TOKEN'
+    'API access token. Can also be set using the environment variable SPLUNK_ACCESS_TOKEN'
   )
   .showHelpAfterError(true)
   .description(listProguardDescription)
   .option('--debug', 
     'Enable debug logs')
   .action(async (options) => {
-    const token = options.token || process.env.O11Y_TOKEN;
+    const token = options.token || process.env.SPLUNK_ACCESS_TOKEN;
     if (!token) {
-      androidCommand.error('Error: API access token is required. Please pass it into the command as the --token option, or set using the environment variable O11Y_TOKEN');
+      androidCommand.error('Error: API access token is required. Please pass it into the command as the --token option, or set using the environment variable SPLUNK_ACCESS_TOKEN');
     }
 
     if (!options.realm || options.realm.trim() === '') {

--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -89,8 +89,8 @@ iOSCommand
   .requiredOption('--path <dSYMs dir or zip>', 'Path to the dSYM[s] directory or zip file.')
   .requiredOption(
     '--realm <value>',
-    'Realm for your organization (example: us0). Can also be set using the environment variable O11Y_REALM',
-    process.env.O11Y_REALM
+    'Realm for your organization (example: us0). Can also be set using the environment variable SPLUNK_REALM',
+    process.env.SPLUNK_REALM
   )
   .option(
     '--token <value>',
@@ -202,8 +202,8 @@ iOSCommand
   .option('--debug', 'Enable debug logs')
   .requiredOption(
     '--realm <value>',
-    'Realm for your organization (example: us0). Can also be set using the environment variable O11Y_REALM',
-    process.env.O11Y_REALM
+    'Realm for your organization (example: us0). Can also be set using the environment variable SPLUNK_REALM',
+    process.env.SPLUNK_REALM
   )
   .option(
     '--token <value>',

--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -48,7 +48,7 @@ export const iOSCommand = program.command('ios');
 
 const shortDescription = 'Upload and list iOS symbolication files (dSYMs)';
 
-const detailedHelp = `For each respective command listed below under 'Commands', please run 'o11y-dem-cli ios <command> --help' for an overview of its usage and options`;
+const detailedHelp = `For each respective command listed below under 'Commands', please run 'splunk-rum ios <command> --help' for an overview of its usage and options`;
 
 const iOSUploadDescription = `This subcommand uploads dSYMs provided as either a zip file, or a dSYM or dSYMs directory.`;
 

--- a/src/commands/ios.ts
+++ b/src/commands/ios.ts
@@ -94,12 +94,12 @@ iOSCommand
   )
   .option(
     '--token <value>',
-    'API access token. Can also be set using the environment variable O11Y_TOKEN'
+    'API access token. Can also be set using the environment variable SPLUNK_ACCESS_TOKEN'
   )
   .option('--debug', 'Enable debug logs')
   .option('--dry-run', 'Perform a trial run with no changes made', false)
   .action(async (options: UploadCommandOptions) => {
-    const token = options.token || process.env.O11Y_TOKEN;
+    const token = options.token || process.env.SPLUNK_ACCESS_TOKEN;
     if (!token) {
       iOSCommand.error(COMMON_ERROR_MESSAGES.TOKEN_NOT_SPECIFIED);
     }
@@ -142,7 +142,7 @@ iOSCommand
 
       logger.info(`Preparing to upload dSYMs files from directory: ${dsymsPath}`);
 
-      const token = options.token || process.env.O11Y_TOKEN;
+      const token = options.token || process.env.SPLUNK_ACCESS_TOKEN;
       if (!token) {
         iOSCommand.error('Error: API access token is required.');
       }
@@ -207,10 +207,10 @@ iOSCommand
   )
   .option(
     '--token <value>',
-    'API access token. Can also be set using the environment variable O11Y_TOKEN'
+    'API access token. Can also be set using the environment variable SPLUNK_ACCESS_TOKEN'
   )
   .action(async (options: ListCommandOptions) => {
-    const token = options.token || process.env.O11Y_TOKEN;
+    const token = options.token || process.env.SPLUNK_ACCESS_TOKEN;
     if (!token) {
       iOSCommand.error('Error: API access token is required.');
     }

--- a/src/commands/sourcemaps.ts
+++ b/src/commands/sourcemaps.ts
@@ -128,8 +128,8 @@ sourcemapsCommand
   )
   .requiredOption(
     '--realm <value>',
-    'Realm for your organization (example: us0).  Can also be set using the environment variable O11Y_REALM',
-    process.env.O11Y_REALM
+    'Realm for your organization (example: us0).  Can also be set using the environment variable SPLUNK_REALM',
+    process.env.SPLUNK_REALM
   )
   .option(
     '--token <value>',

--- a/src/commands/sourcemaps.ts
+++ b/src/commands/sourcemaps.ts
@@ -25,7 +25,7 @@ export const sourcemapsCommand = new Command('sourcemaps');
 
 const shortDescription = 'Prepares JavaScript files to support error symbolication and uploads JavaScript source maps';
 
-const detailedHelp = `For each respective command listed below under 'Commands', please run 'o11y-dem-cli sourcemaps <command> --help' for an overview of its usage and options`;
+const detailedHelp = `For each respective command listed below under 'Commands', please run 'splunk-rum sourcemaps <command> --help' for an overview of its usage and options`;
 
 const injectDescription =
 `Inject a code snippet into your JavaScript bundles to enable automatic source mapping of your application's JavaScript errors.

--- a/src/commands/sourcemaps.ts
+++ b/src/commands/sourcemaps.ts
@@ -133,7 +133,7 @@ sourcemapsCommand
   )
   .option(
     '--token <value>',
-    'API access token.  Can also be set using the environment variable O11Y_TOKEN',
+    'API access token.  Can also be set using the environment variable SPLUNK_ACCESS_TOKEN',
   )
   .option(
     '--app-name <value>',
@@ -161,7 +161,7 @@ sourcemapsCommand
   )
   .action(
     async (options: SourcemapsUploadCliOptions) => {
-      const token = options.token || process.env.O11Y_TOKEN;
+      const token = options.token || process.env.SPLUNK_ACCESS_TOKEN;
       if (!token) {
         sourcemapsCommand.error(COMMON_ERROR_MESSAGES.TOKEN_NOT_SPECIFIED);
       } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ const helpDescription =
 
 For each respective command listed below under 'Commands', please run 'o11y-dem-cli <command>' for an overview of available subcommands and options.
 
-For subcommands like "upload" and "list" that make an API call, please ensure that the realm and token are either passed into the command as options, or set using the environment variables SPLUNK_REALM and O11Y_TOKEN.
+For subcommands like "upload" and "list" that make an API call, please ensure that the realm and token are either passed into the command as options, or set using the environment variables SPLUNK_REALM and SPLUNK_ACCESS_TOKEN.
 `;
 
 program

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ const helpDescription =
 
 For each respective command listed below under 'Commands', please run 'o11y-dem-cli <command>' for an overview of available subcommands and options.
 
-For subcommands like "upload" and "list" that make an API call, please ensure that the realm and token are either passed into the command as options, or set using the environment variables O11Y_REALM and O11Y_TOKEN.
+For subcommands like "upload" and "list" that make an API call, please ensure that the realm and token are either passed into the command as options, or set using the environment variables SPLUNK_REALM and O11Y_TOKEN.
 `;
 
 program

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import { Command } from 'commander';
 import { iOSCommand } from './commands/ios';
 import { androidCommand } from './commands/android';
 import { sourcemapsCommand } from './commands/sourcemaps';
+import * as packageJson from '../package.json';
 
 const program = new Command();
 
@@ -34,7 +35,7 @@ For subcommands like "upload" and "list" that make an API call, please ensure th
 `;
 
 program
-  .version('1.0.0')
+  .version(packageJson.version)
   .description(helpDescription)
   .name('splunk-rum')
   .usage('[command] [subcommand] [options]');

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ const program = new Command();
 const helpDescription =
 `A CLI tool for uploading and displaying of Android, iOS, and Browser symbolication files to and from Splunk O11y Cloud.
 
-For each respective command listed below under 'Commands', please run 'o11y-dem-cli <command>' for an overview of available subcommands and options.
+For each respective command listed below under 'Commands', please run 'splunk-rum <command>' for an overview of available subcommands and options.
 
 For subcommands like "upload" and "list" that make an API call, please ensure that the realm and token are either passed into the command as options, or set using the environment variables SPLUNK_REALM and SPLUNK_ACCESS_TOKEN.
 `;
@@ -36,7 +36,7 @@ For subcommands like "upload" and "list" that make an API call, please ensure th
 program
   .version('1.0.0')
   .description(helpDescription)
-  .name('o11y-dem-cli')
+  .name('splunk-rum')
   .usage('[command] [subcommand] [options]');
   
 program.addCommand(iOSCommand);

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ import * as packageJson from '../package.json';
 const program = new Command();
 
 const helpDescription =
-`A CLI tool for uploading and displaying of Android, iOS, and Browser symbolication files to and from Splunk O11y Cloud.
+`The Splunk RUM CLI is a tool for uploading and displaying of Android, iOS, and Browser symbolication files to and from Splunk Observability Cloud.
 
 For each respective command listed below under 'Commands', please run 'splunk-rum <command>' for an overview of available subcommands and options.
 

--- a/src/sourcemaps/index.ts
+++ b/src/sourcemaps/index.ts
@@ -264,7 +264,7 @@ export async function runSourcemapUpload(options: SourceMapUploadOptions, ctx: S
 }
 
 function getSourceMapUploadUrl(realm: string, idPathParam: string): string {
-  const API_BASE_URL = process.env.O11Y_API_BASE_URL || `https://api.${realm}.signalfx.com`;
+  const API_BASE_URL = `https://api.${realm}.signalfx.com`;
   return `${API_BASE_URL}/v2/rum-mfm/source-maps/id/${idPathParam}`;
 }
 

--- a/src/sourcemaps/utils.ts
+++ b/src/sourcemaps/utils.ts
@@ -18,7 +18,7 @@ import { SourceMapInjectOptions } from './index';
 import { throwAsUserFriendlyErrnoException } from '../utils/userFriendlyErrors';
 
 export const SOURCE_MAPPING_URL_COMMENT_PREFIX = '//# sourceMappingURL=';
-export const SNIPPET_PREFIX = `;/* olly sourcemaps inject */`;
+export const SNIPPET_PREFIX = `;/* splunk-rum sourcemaps inject */`;
 export const SNIPPET_TEMPLATE = `${SNIPPET_PREFIX}if (typeof window === 'object') { window.sourceMapIds = window.sourceMapIds || {}; let s = ''; try { throw new Error(); } catch (e) { s = (e.stack.match(/https?:\\/\\/[^\\s]+?(?::\\d+)?(?=:[\\d]+:[\\d]+)/) || [])[0]; } if (s) {window.sourceMapIds[s] = '__SOURCE_MAP_ID_PLACEHOLDER__';}};`;
 
 export const DEFAULT_JS_MAP_GLOB_PATTERN = '**/*.{js,cjs,mjs}.map';

--- a/src/utils/filesystem.ts
+++ b/src/utils/filesystem.ts
@@ -22,7 +22,7 @@ import os from 'node:os';
 import { finished } from 'node:stream/promises';
 import { glob } from 'glob';
 
-const TEMP_FILE_EXTENSION: string = '.olly.tmp';
+const TEMP_FILE_EXTENSION: string = '.splunk.tmp';
 
 /**
  * Returns a list of paths to all files within the given directory.
@@ -89,7 +89,7 @@ export async function cleanupTemporaryFiles(dir: string) {
 /**
  * Return a tempFilePath based on the input filePath:
  *
- *  - path/to/file.js -> path/to/.file.js.olly.tmp
+ *  - path/to/file.js -> path/to/.file.js.splunk.tmp
  */
 function getTempFilePath(filePath: string) {
   const fileName = path.basename(filePath);

--- a/src/utils/filesystem.ts
+++ b/src/utils/filesystem.ts
@@ -89,7 +89,7 @@ export async function cleanupTemporaryFiles(dir: string) {
 /**
  * Return a tempFilePath based on the input filePath:
  *
- *  - path/to/file.js -> path/to/.file.js.splunk.tmp
+ *  - `path/to/file.js` -> `path/to/.file.js${TEMP_FILE_EXTENSION}`
  */
 function getTempFilePath(filePath: string) {
   const fileName = path.basename(filePath);

--- a/src/utils/inputValidations.ts
+++ b/src/utils/inputValidations.ts
@@ -19,7 +19,7 @@ import path from 'path';
 
 export const COMMON_ERROR_MESSAGES = {
   TOKEN_NOT_SPECIFIED: 'Error: API access token is required. Please pass it into the command as the --token option, or set using the environment variable O11Y_TOKEN',
-  REALM_NOT_SPECIFIED: 'Error: Realm is required and cannot be empty. Please pass it into the command as the --realm option, or set using the environment variable O11Y_REALM'
+  REALM_NOT_SPECIFIED: 'Error: Realm is required and cannot be empty. Please pass it into the command as the --realm option, or set using the environment variable SPLUNK_REALM'
 };
 
 // Check if a file exists

--- a/src/utils/inputValidations.ts
+++ b/src/utils/inputValidations.ts
@@ -18,7 +18,7 @@ import fs from 'fs';
 import path from 'path';
 
 export const COMMON_ERROR_MESSAGES = {
-  TOKEN_NOT_SPECIFIED: 'Error: API access token is required. Please pass it into the command as the --token option, or set using the environment variable O11Y_TOKEN',
+  TOKEN_NOT_SPECIFIED: 'Error: API access token is required. Please pass it into the command as the --token option, or set using the environment variable SPLUNK_ACCESS_TOKEN',
   REALM_NOT_SPECIFIED: 'Error: Realm is required and cannot be empty. Please pass it into the command as the --realm option, or set using the environment variable SPLUNK_REALM'
 };
 

--- a/test/sourcemaps/injectFile.test.ts
+++ b/test/sourcemaps/injectFile.test.ts
@@ -67,7 +67,7 @@ describe('injectFile', () => {
       expect.arrayContaining([
         'line 1',
         'line 2',
-        `;/* olly sourcemaps inject */if (typeof window === 'object') { window.sourceMapIds = window.sourceMapIds || {}; let s = ''; try { throw new Error(); } catch (e) { s = (e.stack.match(/https?:\\/\\/[^\\s]+?(?::\\d+)?(?=:[\\d]+:[\\d]+)/) || [])[0]; } if (s) {window.sourceMapIds[s] = '647366e7-d3db-6cf4-8693-2c321c377d5a';}};`
+        `;/* splunk-rum sourcemaps inject */if (typeof window === 'object') { window.sourceMapIds = window.sourceMapIds || {}; let s = ''; try { throw new Error(); } catch (e) { s = (e.stack.match(/https?:\\/\\/[^\\s]+?(?::\\d+)?(?=:[\\d]+:[\\d]+)/) || [])[0]; } if (s) {window.sourceMapIds[s] = '647366e7-d3db-6cf4-8693-2c321c377d5a';}};`
       ])
     );
   });
@@ -87,7 +87,7 @@ describe('injectFile', () => {
       expect.arrayContaining([
         'line 1',
         'line 2',
-        `;/* olly sourcemaps inject */if (typeof window === 'object') { window.sourceMapIds = window.sourceMapIds || {}; let s = ''; try { throw new Error(); } catch (e) { s = (e.stack.match(/https?:\\/\\/[^\\s]+?(?::\\d+)?(?=:[\\d]+:[\\d]+)/) || [])[0]; } if (s) {window.sourceMapIds[s] = '647366e7-d3db-6cf4-8693-2c321c377d5a';}};`,
+        `;/* splunk-rum sourcemaps inject */if (typeof window === 'object') { window.sourceMapIds = window.sourceMapIds || {}; let s = ''; try { throw new Error(); } catch (e) { s = (e.stack.match(/https?:\\/\\/[^\\s]+?(?::\\d+)?(?=:[\\d]+:[\\d]+)/) || [])[0]; } if (s) {window.sourceMapIds[s] = '647366e7-d3db-6cf4-8693-2c321c377d5a';}};`,
         '//# sourceMappingURL=file.js.map'
       ])
     );
@@ -97,7 +97,7 @@ describe('injectFile', () => {
     mockJsFileContentBeforeInjection([
       'line 1',
       'line 2',
-      `;/* olly sourcemaps inject */if (typeof window === 'object') { window.sourceMapIds = window.sourceMapIds || {}; let s = ''; try { throw new Error(); } catch (e) { s = (e.stack.match(/https?:\\/\\/[^\\s]+?(?::\\d+)?(?=:[\\d]+:[\\d]+)/) || [])[0]; } if (s) {window.sourceMapIds[s] = '88888888-8888-8888-8888-888888888888';}};`,
+      `;/* splunk-rum sourcemaps inject */if (typeof window === 'object') { window.sourceMapIds = window.sourceMapIds || {}; let s = ''; try { throw new Error(); } catch (e) { s = (e.stack.match(/https?:\\/\\/[^\\s]+?(?::\\d+)?(?=:[\\d]+:[\\d]+)/) || [])[0]; } if (s) {window.sourceMapIds[s] = '88888888-8888-8888-8888-888888888888';}};`,
       '//# sourceMappingURL=file.js.map',
     ]);
     const mockOverwriteFn = mockJsFileOverwrite();
@@ -109,7 +109,7 @@ describe('injectFile', () => {
       expect.arrayContaining([
         'line 1',
         'line 2',
-        `;/* olly sourcemaps inject */if (typeof window === 'object') { window.sourceMapIds = window.sourceMapIds || {}; let s = ''; try { throw new Error(); } catch (e) { s = (e.stack.match(/https?:\\/\\/[^\\s]+?(?::\\d+)?(?=:[\\d]+:[\\d]+)/) || [])[0]; } if (s) {window.sourceMapIds[s] = '647366e7-d3db-6cf4-8693-2c321c377d5a';}};`,
+        `;/* splunk-rum sourcemaps inject */if (typeof window === 'object') { window.sourceMapIds = window.sourceMapIds || {}; let s = ''; try { throw new Error(); } catch (e) { s = (e.stack.match(/https?:\\/\\/[^\\s]+?(?::\\d+)?(?=:[\\d]+:[\\d]+)/) || [])[0]; } if (s) {window.sourceMapIds[s] = '647366e7-d3db-6cf4-8693-2c321c377d5a';}};`,
         '//# sourceMappingURL=file.js.map'
       ])
     );
@@ -135,7 +135,7 @@ describe('injectFile', () => {
         '  line7  ',
         '',
         'line9  ',
-        `;/* olly sourcemaps inject */if (typeof window === 'object') { window.sourceMapIds = window.sourceMapIds || {}; let s = ''; try { throw new Error(); } catch (e) { s = (e.stack.match(/https?:\\/\\/[^\\s]+?(?::\\d+)?(?=:[\\d]+:[\\d]+)/) || [])[0]; } if (s) {window.sourceMapIds[s] = '647366e7-d3db-6cf4-8693-2c321c377d5a';}};`,
+        `;/* splunk-rum sourcemaps inject */if (typeof window === 'object') { window.sourceMapIds = window.sourceMapIds || {}; let s = ''; try { throw new Error(); } catch (e) { s = (e.stack.match(/https?:\\/\\/[^\\s]+?(?::\\d+)?(?=:[\\d]+:[\\d]+)/) || [])[0]; } if (s) {window.sourceMapIds[s] = '647366e7-d3db-6cf4-8693-2c321c377d5a';}};`,
         '//# sourceMappingURL=file.js.map'
       ])
     );
@@ -145,7 +145,7 @@ describe('injectFile', () => {
     mockJsFileContentBeforeInjection([
       'line 1',
       'line 2',
-      `;/* olly sourcemaps inject */if (typeof window === 'object') { window.sourceMapIds = window.sourceMapIds || {}; let s = ''; try { throw new Error(); } catch (e) { s = (e.stack.match(/https?:\\/\\/[^\\s]+?(?::\\d+)?(?=:[\\d]+:[\\d]+)/) || [])[0]; } if (s) {window.sourceMapIds[s] = '647366e7-d3db-6cf4-8693-2c321c377d5a';}};`,
+      `;/* splunk-rum sourcemaps inject */if (typeof window === 'object') { window.sourceMapIds = window.sourceMapIds || {}; let s = ''; try { throw new Error(); } catch (e) { s = (e.stack.match(/https?:\\/\\/[^\\s]+?(?::\\d+)?(?=:[\\d]+:[\\d]+)/) || [])[0]; } if (s) {window.sourceMapIds[s] = '647366e7-d3db-6cf4-8693-2c321c377d5a';}};`,
       '//# sourceMappingURL=file.js.map'
     ]);
     const mockOverwriteFn = mockJsFileOverwrite();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
+    "resolveJsonModule": true,
     "skipLibCheck": true,
     "types": ["node", "jest"]
   },


### PR DESCRIPTION
Updated the command name, environment variable names, and other terms in the help and README:
* CLI tool is now "splunk-rum"
* package is now "@splunk/rum-cli"
* O11Y_REALM -> `SPLUNK_REALM`
* O11Y_TOKEN -> `SPLUNK_ACCESS_TOKEN`
* O11y DEM -> Splunk RUM

Other changes:
 * added steps to "Build and Develop" in the README section
 * fixed `--version` option to read from package.json
